### PR TITLE
fix: services dropdown in route /blog/<slug>

### DIFF
--- a/app/pages/blog/_slug.vue
+++ b/app/pages/blog/_slug.vue
@@ -54,7 +54,7 @@
               <!--end article title-->
               <div class="blogdesc">
                 <div v-if="blog.description">
-                  <p>{{ sanitizedDescription }}</p>
+                  <div v-html="blog.description"></div>
                 </div>
                 <div v-if="blog.content" v-html="blog.content"></div>
               </div>
@@ -267,13 +267,6 @@ export default {
         },
       ],
     };
-  },
-
-  computed: {
-    sanitizedDescription() {
-      // Replace <p> tags with an empty string
-      return this.blog.description.replace(/<\/?p>/g, "");
-    },
   },
   methods: {
     strippedHtml(description) {


### PR DESCRIPTION
- fixed services dropdown that not opened in below routes:
https://www.improwised.com/blog/lets-break-barriers-embrace-the-diversity/
https://www.improwised.com/blog/revamping-the-improwised-technologies-website-blog/
