### PR TITLE
Remove trailing slash when generate routes

### DIFF
--- a/app/nuxt.config.js
+++ b/app/nuxt.config.js
@@ -97,6 +97,7 @@ export default {
     dir: "public",
     fallback: false,
     interval: 2000,
+    subFolders: false
   },
 
 


### PR DESCRIPTION
Remove trailing slash when generate routes